### PR TITLE
feat(typo-checker): 新增 zh-tw 文章自動錯字／重複字檢查 workflow

### DIFF
--- a/.github/workflows/ZMediumToMarkdown.yml
+++ b/.github/workflows/ZMediumToMarkdown.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   contents: write
+  issues: write
 
 concurrency:
   group: zmedium-to-markdown
@@ -91,6 +92,11 @@ jobs:
       - name: Optimize photos (webp + photos.json)
         run: python tools/translators/optimize_photos.py
 
+      - name: Typo & duplicate-character check (zh-tw)
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: python tools/translators/typo_checker.py
+
       - name: Generate SEO metadata
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
@@ -137,3 +143,42 @@ jobs:
             --author="ZMediumToMarkdown <zhgchgli@gmail.com>"
           git pull --rebase --autostash origin "${GITHUB_REF_NAME}"
           git push origin "HEAD:${GITHUB_REF_NAME}"
+
+      - name: Open issue for typo fixes
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -e
+          if [[ ! -f .typo-fixes.json ]]; then
+            echo "no report file — nothing to do"
+            exit 0
+          fi
+          fixes_count=$(jq '[.files[].changes | length] | add // 0' .typo-fixes.json)
+          file_count=$(jq '.files | length' .typo-fixes.json)
+          if [[ "$fixes_count" -eq 0 ]]; then
+            echo "no typo fixes this run — skip issue"
+            exit 0
+          fi
+          today=$(date -u +%Y-%m-%d)
+          title="[typo-checker] ${today}: ${file_count} 個檔案 / ${fixes_count} 處自動修正"
+          {
+            echo "本次 ZMediumToMarkdown 排程在 zh-tw 文章中偵測到並 **已自動 commit** 以下錯字／重複字修正，請 review。"
+            echo
+            jq -r '
+              .files[] |
+              "## " + .file,
+              (.changes[] | "- `" + .before + "` → `" + .after + "`" + (if (.reason // "") | (. != "" and . != "cached") then " — " + .reason else "" end)),
+              ""
+            ' .typo-fixes.json
+            echo
+            echo "---"
+            echo
+            echo "若有誤判請手動 revert 對應 commit，並在此 issue 留言以便調整 \`tools/translators/typo_checker.py\` prompt。"
+            echo
+            echo "🔁 Workflow run: ${RUN_URL}"
+          } > .typo-fixes.body.md
+          gh issue create -R "$REPO" -t "$title" -F .typo-fixes.body.md -l typo-checker || \
+            gh issue create -R "$REPO" -t "$title" -F .typo-fixes.body.md

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ assets/.DS_Store
 
 # Translator local venv (cache/ is tracked so re-runs reuse translations)
 tools/translators/.venv/
+
+# typo_checker.py per-run report (consumed by workflow to open issue)
+/.typo-fixes.json

--- a/tools/translators/README.md
+++ b/tools/translators/README.md
@@ -21,6 +21,19 @@ The cache is committed to git so re-runs across machines reuse translations.
 | `translator.py jp` | `L10n/posts/jp/` | OpenAI GPT-4.1-mini | API tokens |
 | `translator_jp.py` | (alias) | Calls `translator.py jp` | — |
 | `translator_cn.py` | `L10n/posts/zh-cn/` | OpenCC (Traditional → Simplified) | Free, deterministic |
+| `typo_checker.py` | `L10n/posts/zh-tw/` (in-place) | OpenAI GPT-4.1-mini | API tokens |
+
+`typo_checker.py` runs **after fetch, before translation** in
+`.github/workflows/ZMediumToMarkdown.yml`. It walks each Markdown block via
+mistune, asks the model to flag only obvious typos and duplicate
+characters / phrases (intentional reduplication and ambiguous variants are
+skipped by the prompt), rewrites the file in place when fixes apply, and
+emits `.typo-fixes.json` at repo root. The workflow's final step opens a
+GitHub issue listing every change so changes can be reviewed.
+
+Per-post cache lives at `tools/translators/cache/typo_check/{sub}/{filename}.json`
+with shape `{"source_hash": "...", "blocks": {<original block>: <fixed or same>}}`.
+A matching `source_hash` skips the file entirely (zero API calls).
 
 ## Setup
 

--- a/tools/translators/typo_checker.py
+++ b/tools/translators/typo_checker.py
@@ -1,0 +1,257 @@
+#!/usr/bin/env python3
+"""
+Typo & duplicate-character checker for zh-tw posts.
+
+Iterates L10n/posts/zh-tw/{zmediumtomarkdown,ai}/, splits each post into
+Markdown blocks (via mistune), and asks OpenAI to flag only:
+  1. obvious typos (homophone / shape-similar / dropped chars)
+  2. obvious duplicate characters or phrases (e.g. 「首先先」「的的」)
+
+The model is instructed to leave tone, style, ordering, intentional
+reduplication (e.g. 一步一步), and ambiguous variants (度過/渡過, 計畫/計劃)
+untouched. Code blocks, frontmatter, URLs, and Markdown structure are
+never modified.
+
+When a fix is applied the file is rewritten in place and the change is
+recorded in `.typo-fixes.json` at repo root for the workflow to consume.
+
+Per-post cache at tools/translators/cache/typo_check/{sub}/{filename}.json:
+    {"source_hash": "...", "blocks": {"<original block>": "<fixed or same>"}}
+
+Usage:
+    pip install -r tools/translators/requirements.txt
+    OPENAI_API_KEY=sk-... python3 tools/translators/typo_checker.py
+"""
+import argparse
+import concurrent.futures
+import hashlib
+import json
+import os
+import sys
+import threading
+
+import frontmatter
+import mistune
+from mistune.renderers.markdown import MarkdownRenderer
+from openai import OpenAI
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+SRC_LANG = "zh-tw"
+SUBDIRS = ["zmediumtomarkdown", "ai"]
+MODEL = "gpt-4.1-mini"
+CACHE_ROOT = os.path.join(ROOT, "tools", "translators", "cache", "typo_check")
+FIXES_REPORT = os.path.join(ROOT, ".typo-fixes.json")
+
+SYSTEM_PROMPT = (
+    "你是正體中文校稿員，專門抓「明顯的打字錯誤」與「重複字／詞」。"
+    "我會給你一段 Markdown 文字片段。請只在 100% 確定的情況下做出修正。"
+    "\n\n"
+    "可以修正的範圍："
+    "\n1. 重複字／詞：明顯多打了字（例：「首先先」→「首先」、「的的」→「的」、"
+    "「米家米家」→「米家」、「你問我問我他」→「你問我、我問他」、「token 帶入帶入」→「token 帶入」）"
+    "\n2. 同音／形近誤字：明顯打錯字（例：「頗析」→「解析」、「米加」→「米家」、"
+    "「要馬」→「要嘛」（但「要馬上」是合理用法請保留）、「甚是是」→「甚至是」）"
+    "\n3. 漏字：明顯漏掉常用字"
+    "\n\n"
+    "嚴格保留、不要動的："
+    "\n- 強調用疊字：「一步一步」「一個一個」「一層一層」「很多很多」「很少很少」「好多好多」「好長好長」"
+    "「考驗考驗」「研究研究」「嘗試嘗試」「意思意思」「活動活動」「熊本熊本尊」「還有還有」「啊啊啊啊」"
+    "「又又又」「滾滾滾」「走著走著」"
+    "\n- 作者語氣詞：「其實」「基本上」「事實上」「個人覺得」「我個人」「個人認為」「可以說是」"
+    "「為了要」「然後再」「簡單來說」"
+    "\n- 兩寫皆通的字：度過／渡過、計畫／計劃、啟用／啓用、做為／作為、藉由／籍由"
+    "\n- Markdown 格式、URL、連結文字、檔案路徑、code block、HTML 標籤、`{:target=...}`"
+    "\n- 任何不 100% 確定的情況一律保留"
+    "\n\n"
+    "請以 JSON 格式回應（不要加 codeblock）："
+    '\n{"fixed": "<修正後的整段內容，若無修改就回傳原文>", '
+    '"changes": [{"before": "<原文片段>", "after": "<修正後>", "reason": "<簡短說明>"}]}'
+    "\n\n沒有任何問題時請回應 {\"fixed\": \"<原文>\", \"changes\": []}。"
+)
+
+_fixes_lock = threading.Lock()
+_fixes_report = []
+
+
+def compute_hash(text):
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def cache_path(sub, filename):
+    return os.path.join(CACHE_ROOT, sub, filename + ".json")
+
+
+def load_cache(path):
+    if os.path.exists(path):
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                return json.load(f)
+        except Exception:
+            pass
+    return {}
+
+
+def save_cache(path, data):
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(data, f, ensure_ascii=False, indent=2, sort_keys=True)
+
+
+class TypoCheckRenderer(MarkdownRenderer):
+    """Walks Markdown blocks; checks each via OpenAI unless cached."""
+
+    def __init__(self, client, blocks_cache, file_changes, *a, **kw):
+        super().__init__(*a, **kw)
+        self.client = client
+        self.blocks_cache = blocks_cache  # original -> fixed (may be unchanged)
+        self.file_changes = file_changes  # list of {"before","after","reason"}
+
+    def _check(self, text):
+        if not text or not text.strip():
+            return text
+        # Cache hit: reuse prior verdict
+        if text in self.blocks_cache:
+            cached = self.blocks_cache[text]
+            if cached != text:
+                # already-known fix - record so the issue captures it on first
+                # surfacing of the file on this run too
+                self.file_changes.append({
+                    "before": text,
+                    "after": cached,
+                    "reason": "cached",
+                })
+            return cached
+        # Call OpenAI
+        try:
+            resp = self.client.chat.completions.create(
+                model=MODEL,
+                messages=[
+                    {"role": "system", "content": SYSTEM_PROMPT},
+                    {"role": "user", "content": text},
+                ],
+                temperature=0,
+            )
+            raw = resp.choices[0].message.content.strip()
+            parsed = json.loads(raw)
+        except Exception as e:
+            print(f"  ! check failed for block ({len(text)} chars): {e}")
+            self.blocks_cache[text] = text
+            return text
+
+        fixed = parsed.get("fixed", text) or text
+        changes = parsed.get("changes") or []
+        if changes and fixed != text:
+            for c in changes:
+                self.file_changes.append({
+                    "before": str(c.get("before", "")),
+                    "after": str(c.get("after", "")),
+                    "reason": str(c.get("reason", "")),
+                })
+            print(f"  ✎ fixed block: {len(changes)} change(s)")
+            self.blocks_cache[text] = fixed
+            return fixed
+        # No change → cache as clean
+        self.blocks_cache[text] = text
+        return text
+
+    def block_quote(self, token, state):
+        return self._check(super().block_quote(token, state)) + "\n\n"
+
+    def list(self, token, state):
+        return self._check(super().list(token, state)) + "\n\n"
+
+    def block_code(self, token, state):
+        # Never check or modify code blocks
+        return super().block_code(token, state) + "\n\n"
+
+    def paragraph(self, token, state):
+        return self._check(super().paragraph(token, state)) + "\n\n"
+
+    def heading(self, token, state):
+        return self._check(super().heading(token, state)) + "\n\n"
+
+
+def process_file(filename, src_dir, sub, api_key):
+    src_path = os.path.join(src_dir, filename)
+    cache_p = cache_path(sub, filename)
+
+    try:
+        with open(src_path, "r", encoding="utf-8") as f:
+            post = frontmatter.load(f)
+    except Exception as e:
+        print(f"✗ read failed: {filename} — {e}")
+        return
+
+    src_hash = compute_hash(post.content)
+    cache = load_cache(cache_p)
+
+    # Skip if file content hash matches cache and no fixes were stashed.
+    if cache.get("source_hash") == src_hash:
+        # Already checked this exact content. Nothing to do.
+        return
+
+    print(f"… checking: {sub}/{filename}")
+    client = OpenAI(api_key=api_key)
+    blocks_cache = dict(cache.get("blocks") or {})
+    file_changes = []
+
+    md = mistune.create_markdown(
+        renderer=TypoCheckRenderer(
+            client=client,
+            blocks_cache=blocks_cache,
+            file_changes=file_changes,
+        )
+    )
+    new_content = md(post.content).replace("|", r"\\|")
+
+    if file_changes and new_content != post.content:
+        post.content = new_content
+        with open(src_path, "w", encoding="utf-8") as f:
+            f.write(frontmatter.dumps(post))
+        new_hash = compute_hash(new_content)
+        with _fixes_lock:
+            _fixes_report.append({
+                "file": os.path.relpath(src_path, ROOT),
+                "changes": file_changes,
+            })
+        print(f"✓ wrote fixes: {filename} ({len(file_changes)} change(s))")
+    else:
+        new_hash = src_hash
+
+    save_cache(cache_p, {"source_hash": new_hash, "blocks": blocks_cache})
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Check typos in zh-tw posts via OpenAI.")
+    parser.add_argument("--api-key", help="OpenAI API key (or env OPENAI_API_KEY)")
+    parser.add_argument("--max-workers", type=int, default=5)
+    args = parser.parse_args()
+
+    api_key = args.api_key or os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        print("✗ Missing OpenAI key. Pass --api-key or set OPENAI_API_KEY.", file=sys.stderr)
+        sys.exit(1)
+
+    for sub in SUBDIRS:
+        src_dir = os.path.join(ROOT, "L10n", "posts", SRC_LANG, sub)
+        if not os.path.isdir(src_dir):
+            continue
+        files = sorted(f for f in os.listdir(src_dir) if f.endswith((".md", ".markdown")))
+        with concurrent.futures.ThreadPoolExecutor(max_workers=args.max_workers) as ex:
+            futures = [ex.submit(process_file, f, src_dir, sub, api_key) for f in files]
+            for fut in concurrent.futures.as_completed(futures):
+                try:
+                    fut.result()
+                except Exception as e:
+                    print(f"✗ task error: {e}", file=sys.stderr)
+
+    # Always write the report (even if empty) so the workflow has a stable
+    # file to read.
+    with open(FIXES_REPORT, "w", encoding="utf-8") as f:
+        json.dump({"files": _fixes_report}, f, ensure_ascii=False, indent=2)
+    total_changes = sum(len(item["changes"]) for item in _fixes_report)
+    print(f"📝 report: {len(_fixes_report)} file(s), {total_changes} change(s) → {FIXES_REPORT}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

新增 zh-tw 文章自動錯字／重複字檢查腳本，整合至 `ZMediumToMarkdown.yml` workflow，每次抓取或更新 Medium 文章後會自動跑一遍，修正後直接寫回原檔並開 issue 供 review。

### 新增 / 變更

- **`tools/translators/typo_checker.py`**：新檔。
  - 對 `L10n/posts/zh-tw/{zmediumtomarkdown,ai}/` 內每篇 `.md` 用 mistune 拆 block，逐 block 串 OpenAI `gpt-4.1-mini` 做檢查。
  - **保守模式**：prompt 只要求修「明顯打錯字」與「重複字／詞」（如「首先先」「的的」「米加→米家」「頗析→解析」「要馬→要嘛」），明確要求保留強調疊字（「一步一步」「考驗考驗」「熊本熊本尊」）、作者語氣詞（「其實」「為了要」「個人覺得」）與兩寫皆通的字（「度過／渡過」「計畫／計劃」）。
  - **per-post cache** 至 `tools/translators/cache/typo_check/{sub}/{filename}.json`（`{"source_hash": "...", "blocks": {<原 block>: <修正後或同原文>}}`）；同 `source_hash` 直接 skip 不打 API，與 `translator.py` 同模式。
  - 修正後寫回原檔，並輸出 `.typo-fixes.json` 列出所有變動。
- **`.github/workflows/ZMediumToMarkdown.yml`**：
  - 加上 `issues: write` 權限。
  - 在「Move fetched posts back → Set up Python → Optimize photos」**之後、SEO/翻譯之前**插入 `Typo & duplicate-character check (zh-tw)` step（這樣修正會反映到後續所有翻譯與 SEO 結果中）。
  - 在最後「Commit and push fetched posts」之後新增 `Open issue for typo fixes` step，用 `gh issue create` 開 issue 列出每個檔案的 before / after。
- **`.gitignore`**：忽略 `/.typo-fixes.json`（每次 workflow run 重新產生）。
- **`tools/translators/README.md`**：補充 `typo_checker.py` 的角色與 cache 結構說明。

### 設計取捨

- 為什麼放在「fetch 後、翻譯前」：這樣翻譯／SEO 是基於已清乾淨的 zh-tw 原文，避免錯字被翻成多語系。
- 為什麼選 block 級而不是檔案級 OpenAI 呼叫：mistune 拆出的 block 通常 < 1KB，prompt 簡單，模型較不容易誤判；同時方便用「block 文字」當 cache key 重複利用。
- 為什麼不直接走 PR：使用者選擇直接 commit + 開 issue review；workflow 已經有自己的 commit-and-push 步驟（修正會跟 fetched posts 一起進 commit），issue 作為事後審查記錄。誤判時手動 revert + 在 issue 留言調 prompt。
- 為什麼用 `temperature=0`：typo check 要可重現，不要創意。

### 成本估計

第一次跑會對 130+ 個 zh-tw 檔的所有 block 各打一次 API（粗估 ~10K calls，gpt-4.1-mini 約 USD $1–2）。建立 cache 後，後續只有「新文章」或「Medium 更新內容」的 block 會打 API，月 cron 一次基本上接近免費。

## Test plan

- [ ] 手動 trigger `ZMediumToMarkdown` workflow，確認：
  - [ ] typo_checker step 跑完無錯
  - [ ] 若有修正：commit message 含修正內容、`Open issue for typo fixes` step 開出 issue，內容對照正確
  - [ ] 若無修正：issue step 顯示「no typo fixes this run — skip issue」並結束 0
- [ ] 觀察首次跑完後 `tools/translators/cache/typo_check/` 是否被一起 commit
- [ ] 後續第二次 trigger，確認 cache 命中、API 呼叫數大幅下降

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AU1nY8wsHJFxq5SHecLCM6)_