### PR TITLE
feat(typo-checker): --seed 模式 + 預先標記現有 zh-tw 文章為已檢查

### DIFF
--- a/tools/translators/README.md
+++ b/tools/translators/README.md
@@ -35,6 +35,12 @@ Per-post cache lives at `tools/translators/cache/typo_check/{sub}/{filename}.jso
 with shape `{"source_hash": "...", "blocks": {<original block>: <fixed or same>}}`.
 A matching `source_hash` skips the file entirely (zero API calls).
 
+The repo ships with the cache **pre-seeded** for every existing zh-tw post
+(via `python typo_checker.py --seed`), so on the first workflow run all
+existing articles are skipped and only newly-fetched or content-updated
+articles trigger OpenAI calls. To force a re-check of a single post, delete
+its cache JSON and re-run.
+
 ## Setup
 
 ```bash

--- a/tools/translators/cache/typo_check/ai/2024-12-02-sanin.md.json
+++ b/tools/translators/cache/typo_check/ai/2024-12-02-sanin.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "da418f7a752309bf9e3bfa23ce09d92872a04b8e9bffe11a167ac80bc033ed28"
+}

--- a/tools/translators/cache/typo_check/ai/2025-10-10-atami.md.json
+++ b/tools/translators/cache/typo_check/ai/2025-10-10-atami.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "8c9192bb4254b5b4b5d7cae5e527c61d3e6cfd3917f6beedb4685fcccb9336f6"
+}

--- a/tools/translators/cache/typo_check/ai/2026-01-16-cdc.md.json
+++ b/tools/translators/cache/typo_check/ai/2026-01-16-cdc.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "9d75280df2347aadd0d1ff947518d109db7d00d22e7354276fc2d103a3d6a9ea"
+}

--- a/tools/translators/cache/typo_check/ai/2026-01-20-appjobstw.md.json
+++ b/tools/translators/cache/typo_check/ai/2026-01-20-appjobstw.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "6358c1c4c8aed7a1ce3bb13601f02f511893c2782d56f40faa257164924ec24f"
+}

--- a/tools/translators/cache/typo_check/ai/2026-04-29-tax.md.json
+++ b/tools/translators/cache/typo_check/ai/2026-04-29-tax.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "20b0414ca1d17911b7e5737417387412061366a09e6a4ea56df3bcfa947e169f"
+}

--- a/tools/translators/cache/typo_check/zmediumtomarkdown/2018-10-06-b7a3fb3d5531.md.json
+++ b/tools/translators/cache/typo_check/zmediumtomarkdown/2018-10-06-b7a3fb3d5531.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "6778e28f3a95acab294775bac61d7cc7aa5d72b55b5ea6decf42a14e1a5edee2"
+}

--- a/tools/translators/cache/typo_check/zmediumtomarkdown/2018-10-13-e37d66ea1146.md.json
+++ b/tools/translators/cache/typo_check/zmediumtomarkdown/2018-10-13-e37d66ea1146.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "6bacd69cc1973670fb18351f3c7e204b1fbef5bb1155de2279d8fcc0e03952ef"
+}

--- a/tools/translators/cache/typo_check/zmediumtomarkdown/2018-10-15-cb6eba52a342.md.json
+++ b/tools/translators/cache/typo_check/zmediumtomarkdown/2018-10-15-cb6eba52a342.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "5db8ceee51f0296dec60f8f7536b61c11523a1b8f2598adeedc5783757634547"
+}

--- a/tools/translators/cache/typo_check/zmediumtomarkdown/2018-10-16-9a9aa892f9a9.md.json
+++ b/tools/translators/cache/typo_check/zmediumtomarkdown/2018-10-16-9a9aa892f9a9.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "b1506ad0096cdb1d836d22fae8ee14374487050f3157548ec4183e5b2ac2cdef"
+}

--- a/tools/translators/cache/typo_check/zmediumtomarkdown/2018-10-17-793bf2cdda0f.md.json
+++ b/tools/translators/cache/typo_check/zmediumtomarkdown/2018-10-17-793bf2cdda0f.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "da2a226877202440453c20880a66dd42b0c1386cdc96b8bf8993a03be3743602"
+}

--- a/tools/translators/cache/typo_check/zmediumtomarkdown/2018-10-18-1ca246e27273.md.json
+++ b/tools/translators/cache/typo_check/zmediumtomarkdown/2018-10-18-1ca246e27273.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "583263c6e624859d4b76f07da34f7e518e4f5864b8ea837ff7cb014b61d90ba4"
+}

--- a/tools/translators/cache/typo_check/zmediumtomarkdown/2018-10-25-a4bc3bce7513.md.json
+++ b/tools/translators/cache/typo_check/zmediumtomarkdown/2018-10-25-a4bc3bce7513.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "a8400f23bdf6e6c3e36c0c6432c6c9143f7d143560aff36304f4d3205663cb1a"
+}

--- a/tools/translators/cache/typo_check/zmediumtomarkdown/2018-11-01-ade9e745a4bf.md.json
+++ b/tools/translators/cache/typo_check/zmediumtomarkdown/2018-11-01-ade9e745a4bf.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "4b5c50610c11a3df34ae010bfc96a9e6adf1304542df439383987488b9aac967"
+}

--- a/tools/translators/cache/typo_check/zmediumtomarkdown/2018-11-02-fd7f92d52baa.md.json
+++ b/tools/translators/cache/typo_check/zmediumtomarkdown/2018-11-02-fd7f92d52baa.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "e94fc8fc4b05ddec50e1cf7153333cad4ed33cde273b881e29950c4ddcc302aa"
+}

--- a/tools/translators/cache/typo_check/zmediumtomarkdown/2018-11-03-8d863bcd1c55.md.json
+++ b/tools/translators/cache/typo_check/zmediumtomarkdown/2018-11-03-8d863bcd1c55.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "0c7c7f8c5d8a40e212df75edd7f47b767cb24f610da1726bcb4110670f2529cb"
+}

--- a/tools/translators/cache/typo_check/zmediumtomarkdown/2018-11-12-f644db1bb8bf.md.json
+++ b/tools/translators/cache/typo_check/zmediumtomarkdown/2018-11-12-f644db1bb8bf.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "7e27676458ec97e27627c8b9d4cd30dc86a66417d83835cb5d4daf799fec1fc4"
+}

--- a/tools/translators/cache/typo_check/zmediumtomarkdown/2018-11-26-a2920e33e73e.md.json
+++ b/tools/translators/cache/typo_check/zmediumtomarkdown/2018-11-26-a2920e33e73e.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "a9ccfd632434cf9c49c540fbfe9669dd3a459abd93c2eb751018c13599d3b7d5"
+}

--- a/tools/translators/cache/typo_check/zmediumtomarkdown/2019-02-05-e85d77b05061.md.json
+++ b/tools/translators/cache/typo_check/zmediumtomarkdown/2019-02-05-e85d77b05061.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "9f21a12a761009c8703461d55c818fb9f57a07c38489851396b52ea1c56e2cc1"
+}

--- a/tools/translators/cache/typo_check/zmediumtomarkdown/2019-02-06-6012b7b4f612.md.json
+++ b/tools/translators/cache/typo_check/zmediumtomarkdown/2019-02-06-6012b7b4f612.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "87647602365c551592bc7a91de16a3c05f083e7a7e32a925e9445f864cbce518"
+}

--- a/tools/translators/cache/typo_check/zmediumtomarkdown/2019-04-27-ac557047d206.md.json
+++ b/tools/translators/cache/typo_check/zmediumtomarkdown/2019-04-27-ac557047d206.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "de6c2ab5f03e899a5df8b0580ba9f3224b738ec826ec6a997d65487532f38f94"
+}

--- a/tools/translators/cache/typo_check/zmediumtomarkdown/2019-04-29-c5e7e580c341.md.json
+++ b/tools/translators/cache/typo_check/zmediumtomarkdown/2019-04-29-c5e7e580c341.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "85094d9f9c7fee2f03011faebff5a80d5da04cde38da432adfaae313ab351310"
+}

--- a/tools/translators/cache/typo_check/zmediumtomarkdown/2019-05-01-33afa0ae557d.md.json
+++ b/tools/translators/cache/typo_check/zmediumtomarkdown/2019-05-01-33afa0ae557d.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "fa7870c242397101a4b8d2cae9f2759de04fca4fedefb12d65ff142ffd51e8a4"
+}

--- a/tools/translators/cache/typo_check/zmediumtomarkdown/2019-07-05-c3150cdc85dd.md.json
+++ b/tools/translators/cache/typo_check/zmediumtomarkdown/2019-07-05-c3150cdc85dd.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "86e4e4fc377edc194ce8f02242df3bbf72cb40a91bd6fca01c1f57f36eb210a8"
+}

--- a/tools/translators/cache/typo_check/zmediumtomarkdown/2019-07-08-a66ce3dc8bb9.md.json
+++ b/tools/translators/cache/typo_check/zmediumtomarkdown/2019-07-08-a66ce3dc8bb9.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "d638ff74133a95cf3d6bee9c001367109e73efa568e548b7b8f639f27d02ba9f"
+}

--- a/tools/translators/cache/typo_check/zmediumtomarkdown/2019-07-24-729d7b6817a4.md.json
+++ b/tools/translators/cache/typo_check/zmediumtomarkdown/2019-07-24-729d7b6817a4.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "7fb7340a03a4315a9dc9d4b9bc5f489682f211ee46a77a98e0841f9be949476f"
+}

--- a/tools/translators/cache/typo_check/zmediumtomarkdown/2019-09-20-46410aaada00.md.json
+++ b/tools/translators/cache/typo_check/zmediumtomarkdown/2019-09-20-46410aaada00.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "96b24fcd70d5a8694edb108cadc403ad0e3500c4c96e01c08dd82ec2fdf60b03"
+}

--- a/tools/translators/cache/typo_check/zmediumtomarkdown/2019-09-22-4079036c85c2.md.json
+++ b/tools/translators/cache/typo_check/zmediumtomarkdown/2019-09-22-4079036c85c2.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "171eb1a1ad7cf178e79dfcb30db257fe49772009c148220684e5aee191f67188"
+}

--- a/tools/translators/cache/typo_check/zmediumtomarkdown/2019-09-26-21119db777dd.md.json
+++ b/tools/translators/cache/typo_check/zmediumtomarkdown/2019-09-26-21119db777dd.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "3121d8a873e9281d362344d64a897d1e7edf323ee0e76dbbff14e038df7f6559"
+}

--- a/tools/translators/cache/typo_check/zmediumtomarkdown/2019-09-26-bcff7c157941.md.json
+++ b/tools/translators/cache/typo_check/zmediumtomarkdown/2019-09-26-bcff7c157941.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "dfc82396c9c1ef3e05340f4e154c539a59b930db388b1b0e1457d61b89a4388b"
+}

--- a/tools/translators/cache/typo_check/zmediumtomarkdown/2019-11-11-b08ef940c196.md.json
+++ b/tools/translators/cache/typo_check/zmediumtomarkdown/2019-11-11-b08ef940c196.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "8f5689ef27121999f3ccd9196a7d92618fe944e3cff992c552b304105c5a4128"
+}

--- a/tools/translators/cache/typo_check/zmediumtomarkdown/2020-01-11-14cee137c565.md.json
+++ b/tools/translators/cache/typo_check/zmediumtomarkdown/2020-01-11-14cee137c565.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "ee4c6e182a25cffde0a3236c76a5cadc1e5c516a28c5a8606ce65cc26324d27d"
+}

--- a/tools/translators/cache/typo_check/zmediumtomarkdown/2020-01-12-94a4020edb82.md.json
+++ b/tools/translators/cache/typo_check/zmediumtomarkdown/2020-01-12-94a4020edb82.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "4e0c997800a0a8a7c36136a63356d5e99ba6af7073c6b8f3f3e15bab309afac6"
+}

--- a/tools/translators/cache/typo_check/zmediumtomarkdown/2020-01-12-d01252331b53.md.json
+++ b/tools/translators/cache/typo_check/zmediumtomarkdown/2020-01-12-d01252331b53.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "c0ff160b3ad70d61e56221204dbee2b2fb3c3b51d2be1b853f741893767d90e6"
+}

--- a/tools/translators/cache/typo_check/zmediumtomarkdown/2020-02-01-a8c2d7ed144b.md.json
+++ b/tools/translators/cache/typo_check/zmediumtomarkdown/2020-02-01-a8c2d7ed144b.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "014e2ad402b775b341df85ac14c2d28927c2221e2b23d9671d0a2b5bbee1b2e0"
+}

--- a/tools/translators/cache/typo_check/zmediumtomarkdown/2020-03-28-7498e1ff93ce.md.json
+++ b/tools/translators/cache/typo_check/zmediumtomarkdown/2020-03-28-7498e1ff93ce.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "d1f467c873fe7983a2718eb327b1fba9749d1552962d673f4f141aa2ebdbf564"
+}

--- a/tools/translators/cache/typo_check/zmediumtomarkdown/2020-04-08-d796bf8e661e.md.json
+++ b/tools/translators/cache/typo_check/zmediumtomarkdown/2020-04-08-d796bf8e661e.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "9a5b77d5c966098a2517d4a9d89181f40f051ef5c1d8d7edba72faaa38b4b610"
+}

--- a/tools/translators/cache/typo_check/zmediumtomarkdown/2020-04-20-99db2a1fbfe5.md.json
+++ b/tools/translators/cache/typo_check/zmediumtomarkdown/2020-04-20-99db2a1fbfe5.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "26dc78b7abfcff14f328492715f8a3d0a5a6c7a97d2d247d89bf496ba15ffeaa"
+}

--- a/tools/translators/cache/typo_check/zmediumtomarkdown/2020-05-10-2e4429f410d6.md.json
+++ b/tools/translators/cache/typo_check/zmediumtomarkdown/2020-05-10-2e4429f410d6.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "30c831013d7994e7d42690124972889acd484dc9323da08deeec5a77deca8eff"
+}

--- a/tools/translators/cache/typo_check/zmediumtomarkdown/2020-06-13-1aa2f8445642.md.json
+++ b/tools/translators/cache/typo_check/zmediumtomarkdown/2020-06-13-1aa2f8445642.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "939e8c9e64019c4212ab2fe3bf98d01ed797a7b6784e791b31ac043b5847cddc"
+}

--- a/tools/translators/cache/typo_check/zmediumtomarkdown/2020-06-17-724a7fb9a364.md.json
+++ b/tools/translators/cache/typo_check/zmediumtomarkdown/2020-06-17-724a7fb9a364.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "1c0cf7c50a2f5710a15dc757d7f9a815e6815351c47afcf26fe1f7d60b031127"
+}

--- a/tools/translators/cache/typo_check/zmediumtomarkdown/2020-06-25-cb00b1977537.md.json
+++ b/tools/translators/cache/typo_check/zmediumtomarkdown/2020-06-25-cb00b1977537.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "b957a26a8c87063968d6bead697f1c904e072e8c235a03f92093d36c2173de9f"
+}

--- a/tools/translators/cache/typo_check/zmediumtomarkdown/2020-07-02-8a04443024e2.md.json
+++ b/tools/translators/cache/typo_check/zmediumtomarkdown/2020-07-02-8a04443024e2.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "459304ba4ad52ab99ab452ee8e44f950c15a484f57b5e3af1ae584b41d94d4f5"
+}

--- a/tools/translators/cache/typo_check/zmediumtomarkdown/2020-09-17-41c49a75a743.md.json
+++ b/tools/translators/cache/typo_check/zmediumtomarkdown/2020-09-17-41c49a75a743.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "a280ede3ee87a0f55cab464d5c70db71e2e8fb58b07b3e863c1ea2fe1a63cdb3"
+}

--- a/tools/translators/cache/typo_check/zmediumtomarkdown/2020-10-14-eab0e984043.md.json
+++ b/tools/translators/cache/typo_check/zmediumtomarkdown/2020-10-14-eab0e984043.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "9fbbb4c00dfccb21988926682d07312620e0b183afb0754aaf7867a1e66903d9"
+}

--- a/tools/translators/cache/typo_check/zmediumtomarkdown/2020-11-02-c0f99f987d9c.md.json
+++ b/tools/translators/cache/typo_check/zmediumtomarkdown/2020-11-02-c0f99f987d9c.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "bc0b40fdbcdd8d2d744ac30cfda9aa36b17553723b8be5a3383d7fde1a8b7379"
+}

--- a/tools/translators/cache/typo_check/zmediumtomarkdown/2020-12-17-c4d7c2ce5a8d.md.json
+++ b/tools/translators/cache/typo_check/zmediumtomarkdown/2020-12-17-c4d7c2ce5a8d.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "dee754358e1e415b6ac60ab1f85a4dc79d85eb4495345fa5ca4033b00af5c66e"
+}

--- a/tools/translators/cache/typo_check/zmediumtomarkdown/2021-01-05-ee47f8f1e2d2.md.json
+++ b/tools/translators/cache/typo_check/zmediumtomarkdown/2021-01-05-ee47f8f1e2d2.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "cfef4c705471b5f2153f1c3c5be05584e06b154056744378d4034aeeb6e77863"
+}

--- a/tools/translators/cache/typo_check/zmediumtomarkdown/2021-01-31-6ce488898003.md.json
+++ b/tools/translators/cache/typo_check/zmediumtomarkdown/2021-01-31-6ce488898003.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "9afd96781f22a7db3fca2d216d085dc1b1b2c93373d5e9fadc517787fdd83d24"
+}

--- a/tools/translators/cache/typo_check/zmediumtomarkdown/2021-02-02-948ed34efa09.md.json
+++ b/tools/translators/cache/typo_check/zmediumtomarkdown/2021-02-02-948ed34efa09.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "9b375b94979c76646053feec78302b7bf4ecccfaaaeb18a03100e870fd324bf5"
+}

--- a/tools/translators/cache/typo_check/zmediumtomarkdown/2021-02-04-12c5026da33d.md.json
+++ b/tools/translators/cache/typo_check/zmediumtomarkdown/2021-02-04-12c5026da33d.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "47617790bf526f6ce0af2d6c622f783655a92e69d08585c0e71f1462d2cdbebd"
+}

--- a/tools/translators/cache/typo_check/zmediumtomarkdown/2021-02-05-87090f101b9a.md.json
+++ b/tools/translators/cache/typo_check/zmediumtomarkdown/2021-02-05-87090f101b9a.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "7af72be77eb720c480c8f54290729dd0d35b2c48b68617eff033fcf425207d2d"
+}

--- a/tools/translators/cache/typo_check/zmediumtomarkdown/2021-02-20-70a1409b149a.md.json
+++ b/tools/translators/cache/typo_check/zmediumtomarkdown/2021-02-20-70a1409b149a.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "589aef24e811ca2b0dd4905988be357ea3fe58d7940566ce563c6f5deb06c35c"
+}

--- a/tools/translators/cache/typo_check/zmediumtomarkdown/2021-02-22-142244e5f07a.md.json
+++ b/tools/translators/cache/typo_check/zmediumtomarkdown/2021-02-22-142244e5f07a.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "76c1b69ebaaf1d1801b3ed662bf9aa7410af235371e26abfa80c3248f9ac68ce"
+}

--- a/tools/translators/cache/typo_check/zmediumtomarkdown/2021-02-23-d9a95d4224ea.md.json
+++ b/tools/translators/cache/typo_check/zmediumtomarkdown/2021-02-23-d9a95d4224ea.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "2f5487a33dfecf705bbec386be3110d411b725eab670fadfaee9dc4e53eefa32"
+}

--- a/tools/translators/cache/typo_check/zmediumtomarkdown/2021-02-24-5ea3311119d8.md.json
+++ b/tools/translators/cache/typo_check/zmediumtomarkdown/2021-02-24-5ea3311119d8.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "95bb01ae4bc28862af238a16861e2426d6700731cbd75b068edfeb6ea19c7c1e"
+}

--- a/tools/translators/cache/typo_check/zmediumtomarkdown/2021-03-14-99a6cef90190.md.json
+++ b/tools/translators/cache/typo_check/zmediumtomarkdown/2021-03-14-99a6cef90190.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "e944fd1c8a41d8efa6994b8746af57d8ff6628243acb0f6cad7a7829bc1fa7b3"
+}

--- a/tools/translators/cache/typo_check/zmediumtomarkdown/2021-03-23-9659db1357e4.md.json
+++ b/tools/translators/cache/typo_check/zmediumtomarkdown/2021-03-23-9659db1357e4.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "cfdf3688dd998a9d1f7e22655c4fbcb081f0cb62d1464c1f2aa81c495d2e2324"
+}

--- a/tools/translators/cache/typo_check/zmediumtomarkdown/2021-04-21-cb0c68c33994.md.json
+++ b/tools/translators/cache/typo_check/zmediumtomarkdown/2021-04-21-cb0c68c33994.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "365a7961767d76c100b9e760d6f899f372bb13183a6a5bf70248086eae90778a"
+}

--- a/tools/translators/cache/typo_check/zmediumtomarkdown/2021-05-05-33f6aabb744f.md.json
+++ b/tools/translators/cache/typo_check/zmediumtomarkdown/2021-05-05-33f6aabb744f.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "40da76ea1711d634c89501a44bdef1d702a25ea3a612762171dc8f1ad29cffe1"
+}

--- a/tools/translators/cache/typo_check/zmediumtomarkdown/2021-06-13-d61062833c1a.md.json
+++ b/tools/translators/cache/typo_check/zmediumtomarkdown/2021-06-13-d61062833c1a.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "46594f00c9e0e6c9c427eb3635b22b4c58f84a90f2f946b53f35e4f7fac93b7f"
+}

--- a/tools/translators/cache/typo_check/zmediumtomarkdown/2021-06-15-ba5773a7bfea.md.json
+++ b/tools/translators/cache/typo_check/zmediumtomarkdown/2021-06-15-ba5773a7bfea.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "b263097d02bcf5e4051b6a08e0a8b19e5642158117aec5741883ec4248c87b8a"
+}

--- a/tools/translators/cache/typo_check/zmediumtomarkdown/2021-07-25-1c9eafd4a190.md.json
+++ b/tools/translators/cache/typo_check/zmediumtomarkdown/2021-07-25-1c9eafd4a190.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "0e296807425a9126ac989cce2a20e49c3e8ddc3f20e1bde3a4dee6b17f513a44"
+}

--- a/tools/translators/cache/typo_check/zmediumtomarkdown/2021-08-07-118e924a1477.md.json
+++ b/tools/translators/cache/typo_check/zmediumtomarkdown/2021-08-07-118e924a1477.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "b8d9e0094663c2d504b9de69952ac42d8f840c2f39d66ed2fa81ddaa51ccacaf"
+}

--- a/tools/translators/cache/typo_check/zmediumtomarkdown/2021-08-07-d414bdbdb8c9.md.json
+++ b/tools/translators/cache/typo_check/zmediumtomarkdown/2021-08-07-d414bdbdb8c9.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "1b856d4a658b4e84873023cc583c5480f50fb3ba008c123639c1f57292606ae3"
+}

--- a/tools/translators/cache/typo_check/zmediumtomarkdown/2021-09-09-11f6c8568154.md.json
+++ b/tools/translators/cache/typo_check/zmediumtomarkdown/2021-09-09-11f6c8568154.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "ce99839c253c5fbd76221b76994e4406fa15c324a3144e3a28f4caddf4b47775"
+}

--- a/tools/translators/cache/typo_check/zmediumtomarkdown/2021-10-19-e77b80cc6f89.md.json
+++ b/tools/translators/cache/typo_check/zmediumtomarkdown/2021-10-19-e77b80cc6f89.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "cc5528573020bf2579d92fee1bc69d03df09a8b70b6b031a9f8e9b1f1d3fb37e"
+}

--- a/tools/translators/cache/typo_check/zmediumtomarkdown/2021-10-24-9a05f632eba0.md.json
+++ b/tools/translators/cache/typo_check/zmediumtomarkdown/2021-10-24-9a05f632eba0.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "f28466af50a0ac2a562afb654b08714ebd5c36876579ddfcc164b1fd6fefd9b2"
+}

--- a/tools/translators/cache/typo_check/zmediumtomarkdown/2021-11-21-793cb8f89b72.md.json
+++ b/tools/translators/cache/typo_check/zmediumtomarkdown/2021-11-21-793cb8f89b72.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "d7dc6f0e035829312ec01e41a74b45fc68d7b778d68d48a7874bd3e812f60809"
+}

--- a/tools/translators/cache/typo_check/zmediumtomarkdown/2022-04-07-78507a8de6a5.md.json
+++ b/tools/translators/cache/typo_check/zmediumtomarkdown/2022-04-07-78507a8de6a5.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "4408d2205c3df55b1e73b21530900018967b5fa20ff0804ad2671feb4902f777"
+}

--- a/tools/translators/cache/typo_check/zmediumtomarkdown/2022-05-28-ddd88a84e177.md.json
+++ b/tools/translators/cache/typo_check/zmediumtomarkdown/2022-05-28-ddd88a84e177.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "aa8a49e63f2c5b5b112a897fd7a6eb3699ccd0577fe12e3bdb7bab81e86a10b9"
+}

--- a/tools/translators/cache/typo_check/zmediumtomarkdown/2022-06-09-a8c2d26cc734.md.json
+++ b/tools/translators/cache/typo_check/zmediumtomarkdown/2022-06-09-a8c2d26cc734.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "a9b35834edbd96dc2eb6c311c65d6dab52e7289d21dacad07451e98e6d5ac46a"
+}

--- a/tools/translators/cache/typo_check/zmediumtomarkdown/2022-07-08-60473cb47550.md.json
+++ b/tools/translators/cache/typo_check/zmediumtomarkdown/2022-07-08-60473cb47550.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "f648540e054bbf9b4d41d0c2ac84bbeb7f84070eff4ebb002e82318a13213788"
+}

--- a/tools/translators/cache/typo_check/zmediumtomarkdown/2022-07-15-48a8526c1300.md.json
+++ b/tools/translators/cache/typo_check/zmediumtomarkdown/2022-07-15-48a8526c1300.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "6482a6dc2ec5250450a343e91e7ca1141566b1e47dc58586b1e398d3b3a281f1"
+}

--- a/tools/translators/cache/typo_check/zmediumtomarkdown/2022-07-16-a0c08d579ab1.md.json
+++ b/tools/translators/cache/typo_check/zmediumtomarkdown/2022-07-16-a0c08d579ab1.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "0f2495aabc3b01fe875add4e096e39cd603666cd48b21bfe2c04c6f69aad4d61"
+}

--- a/tools/translators/cache/typo_check/zmediumtomarkdown/2022-07-20-f1365e51902c.md.json
+++ b/tools/translators/cache/typo_check/zmediumtomarkdown/2022-07-20-f1365e51902c.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "069662ea78cdf309960f2e29466a91546bde25ff14910517f9ca217e13619393"
+}

--- a/tools/translators/cache/typo_check/zmediumtomarkdown/2022-08-10-e36e48bb9265.md.json
+++ b/tools/translators/cache/typo_check/zmediumtomarkdown/2022-08-10-e36e48bb9265.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "6cd1fb54aabfd5f94f824b44f35c6294abb85ba41e21f5d4ef9a848e7b933918"
+}

--- a/tools/translators/cache/typo_check/zmediumtomarkdown/2022-12-02-4b9d09cea5f0.md.json
+++ b/tools/translators/cache/typo_check/zmediumtomarkdown/2022-12-02-4b9d09cea5f0.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "930bb5740aa0941f5f818348ca886a4886517149d71cbbdef4dc83ca08e35587"
+}

--- a/tools/translators/cache/typo_check/zmediumtomarkdown/2023-02-26-a5643de271e4.md.json
+++ b/tools/translators/cache/typo_check/zmediumtomarkdown/2023-02-26-a5643de271e4.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "32fbc78b95b7598a71115424bd656655d5e5f97761ed90d538c36cb244729c3d"
+}

--- a/tools/translators/cache/typo_check/zmediumtomarkdown/2023-03-11-2724f02f6e7.md.json
+++ b/tools/translators/cache/typo_check/zmediumtomarkdown/2023-03-11-2724f02f6e7.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "7607f08f17472a88200b50ff0466f644486b672267fc4b320eb3adee495ef739"
+}

--- a/tools/translators/cache/typo_check/zmediumtomarkdown/2023-03-17-e7c547a5be22.md.json
+++ b/tools/translators/cache/typo_check/zmediumtomarkdown/2023-03-17-e7c547a5be22.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "e515efb0a6d75c242d5954509384ae2aaef9b326714c3784809eccfefaab687f"
+}

--- a/tools/translators/cache/typo_check/zmediumtomarkdown/2023-07-07-76d66c2e34af.md.json
+++ b/tools/translators/cache/typo_check/zmediumtomarkdown/2023-07-07-76d66c2e34af.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "98a2b27f03bea9c918995162065179754e412b4b3f0b93d04f017e3410da278f"
+}

--- a/tools/translators/cache/typo_check/zmediumtomarkdown/2023-07-09-9da2c51fa4f2.md.json
+++ b/tools/translators/cache/typo_check/zmediumtomarkdown/2023-07-09-9da2c51fa4f2.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "91af791dd4cbfb04eae839e200213aa657e50336dff0281a279b2f5f3b08fc08"
+}

--- a/tools/translators/cache/typo_check/zmediumtomarkdown/2023-08-01-382218e15697.md.json
+++ b/tools/translators/cache/typo_check/zmediumtomarkdown/2023-08-01-382218e15697.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "babd6ed336bb1d10ef7ad2f44c3b3e6611cba78899799eb9f73a8a0018dfeb24"
+}

--- a/tools/translators/cache/typo_check/zmediumtomarkdown/2023-08-28-5a5c4b25a83d.md.json
+++ b/tools/translators/cache/typo_check/zmediumtomarkdown/2023-08-28-5a5c4b25a83d.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "3180babef33637abd09e1f559803dcbd4f710a6c09759310c5177637fe70f95f"
+}

--- a/tools/translators/cache/typo_check/zmediumtomarkdown/2023-09-28-7b8a0563c157.md.json
+++ b/tools/translators/cache/typo_check/zmediumtomarkdown/2023-09-28-7b8a0563c157.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "b90087a63526608663a3a09c59c894fe738b781f373da9aa665f0e8cded60149"
+}

--- a/tools/translators/cache/typo_check/zmediumtomarkdown/2023-10-04-d78e0b15a08a.md.json
+++ b/tools/translators/cache/typo_check/zmediumtomarkdown/2023-10-04-d78e0b15a08a.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "9fceea69a75076c4e0847474231b2032f4cf0a8beb000af74c189c33588aefaf"
+}

--- a/tools/translators/cache/typo_check/zmediumtomarkdown/2024-01-09-31b9b3a63abc.md.json
+++ b/tools/translators/cache/typo_check/zmediumtomarkdown/2024-01-09-31b9b3a63abc.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "198411117570cb3fd5358dd922a8af7d6a734b10460a68b5e9504554aaaf17cc"
+}

--- a/tools/translators/cache/typo_check/zmediumtomarkdown/2024-02-16-bd94cc88f9c9.md.json
+++ b/tools/translators/cache/typo_check/zmediumtomarkdown/2024-02-16-bd94cc88f9c9.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "649fdfb897e80006aa97f33983e65c608d8d8700fb14f41152f0a9cdcdd65a15"
+}

--- a/tools/translators/cache/typo_check/zmediumtomarkdown/2024-04-14-f6713ba3fee3.md.json
+++ b/tools/translators/cache/typo_check/zmediumtomarkdown/2024-04-14-f6713ba3fee3.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "a28a4a5787d8f63cc021fedae887c5d4d9f05c84ca7acc242bae9cbf50e33121"
+}

--- a/tools/translators/cache/typo_check/zmediumtomarkdown/2024-05-14-b04f4fba3cf2.md.json
+++ b/tools/translators/cache/typo_check/zmediumtomarkdown/2024-05-14-b04f4fba3cf2.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "142f720ca6619fb6a27ab7b1332bc3271e6ba09ef59e8e6ecb7df44b383be212"
+}

--- a/tools/translators/cache/typo_check/zmediumtomarkdown/2024-05-25-9903c9783a97.md.json
+++ b/tools/translators/cache/typo_check/zmediumtomarkdown/2024-05-25-9903c9783a97.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "74b7d7c6a3ee399105204e970ec68556b1401e36ce526a7c0d7a06d1b71beee1"
+}

--- a/tools/translators/cache/typo_check/zmediumtomarkdown/2024-05-25-9d0f23784359.md.json
+++ b/tools/translators/cache/typo_check/zmediumtomarkdown/2024-05-25-9d0f23784359.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "2a888fa40482bf01ffc223ccca65676de74d75c126a5108988a637f76f450e85"
+}

--- a/tools/translators/cache/typo_check/zmediumtomarkdown/2024-06-01-2981dc0fcd58.md.json
+++ b/tools/translators/cache/typo_check/zmediumtomarkdown/2024-06-01-2981dc0fcd58.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "49e8ed0c07eb5249ac9db8d5f05673dac67fbfe1a7058ec426949c014fded25b"
+}

--- a/tools/translators/cache/typo_check/zmediumtomarkdown/2024-06-20-cb65fd5ab770.md.json
+++ b/tools/translators/cache/typo_check/zmediumtomarkdown/2024-06-20-cb65fd5ab770.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "d54e045ff3c249d4d95d85038320a6f3ff86909aa20a7216d38d8e602e2e429b"
+}

--- a/tools/translators/cache/typo_check/zmediumtomarkdown/2024-07-28-5033090c18ba.md.json
+++ b/tools/translators/cache/typo_check/zmediumtomarkdown/2024-07-28-5033090c18ba.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "527c0de492dcb312c744f8e3a549d597d269273ac86cca55f8378fba309d4a67"
+}

--- a/tools/translators/cache/typo_check/zmediumtomarkdown/2024-08-10-cefdf4d41746.md.json
+++ b/tools/translators/cache/typo_check/zmediumtomarkdown/2024-08-10-cefdf4d41746.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "87a7dfd096fcdaa518f9fb9a9cc8e0fce8dda6abcf86957e01e4f84a21f94583"
+}

--- a/tools/translators/cache/typo_check/zmediumtomarkdown/2024-08-13-755509180ca8.md.json
+++ b/tools/translators/cache/typo_check/zmediumtomarkdown/2024-08-13-755509180ca8.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "552dd286fcfe56604b8b247605b2c361d0c3b79690b1b52951b2c746ded5a4c7"
+}

--- a/tools/translators/cache/typo_check/zmediumtomarkdown/2024-08-19-309d0302877b.md.json
+++ b/tools/translators/cache/typo_check/zmediumtomarkdown/2024-08-19-309d0302877b.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "8e492da0c6b892968ffc25fae70501105fcd9d28e75f18ac6fd5fa25e3af8880"
+}

--- a/tools/translators/cache/typo_check/zmediumtomarkdown/2024-08-20-7584f643c0aa.md.json
+++ b/tools/translators/cache/typo_check/zmediumtomarkdown/2024-08-20-7584f643c0aa.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "cc1a61f53c06be5d53464951157d38a426e48ea8339aee388c5c87e22d511a2a"
+}

--- a/tools/translators/cache/typo_check/zmediumtomarkdown/2024-08-24-b7e7c0938985.md.json
+++ b/tools/translators/cache/typo_check/zmediumtomarkdown/2024-08-24-b7e7c0938985.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "854880651571e2c4658404605850b962c9ef699a6f3064ccca582b2a9304678b"
+}

--- a/tools/translators/cache/typo_check/zmediumtomarkdown/2024-09-06-f4b02ee342a4.md.json
+++ b/tools/translators/cache/typo_check/zmediumtomarkdown/2024-09-06-f4b02ee342a4.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "dacfcae44416a9fe2c6bfe9258f72bc5b3130afbaa59a150d2c00c2e703d089d"
+}

--- a/tools/translators/cache/typo_check/zmediumtomarkdown/2024-09-20-9e43897d99fc.md.json
+++ b/tools/translators/cache/typo_check/zmediumtomarkdown/2024-09-20-9e43897d99fc.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "413d9a371c226a1d5ec82f26126ad67b64f8f0c346f6593f35a0c208dfd5e897"
+}

--- a/tools/translators/cache/typo_check/zmediumtomarkdown/2024-09-22-483af5d93297.md.json
+++ b/tools/translators/cache/typo_check/zmediumtomarkdown/2024-09-22-483af5d93297.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "88b604a9f33e6e025474a7a55e586680e4d25880cc66c71c42c9b4b5ac294262"
+}

--- a/tools/translators/cache/typo_check/zmediumtomarkdown/2024-09-26-0095528cf875.md.json
+++ b/tools/translators/cache/typo_check/zmediumtomarkdown/2024-09-26-0095528cf875.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "8a7113f158c6f1a7f19b33bf9e72bce8b101d06f027c18df2c27b40c2b775ec7"
+}

--- a/tools/translators/cache/typo_check/zmediumtomarkdown/2024-10-12-6922e90ba90c.md.json
+++ b/tools/translators/cache/typo_check/zmediumtomarkdown/2024-10-12-6922e90ba90c.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "d40df1ea018bf89c5dc708436288f664bf3f194303abbac4fb8252753d51b6f1"
+}

--- a/tools/translators/cache/typo_check/zmediumtomarkdown/2024-10-20-1e85b8df2348.md.json
+++ b/tools/translators/cache/typo_check/zmediumtomarkdown/2024-10-20-1e85b8df2348.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "4f754cd1246532cfbd1f9fe7195bceaa62dde847a67cc86d11b1221ca2417a72"
+}

--- a/tools/translators/cache/typo_check/zmediumtomarkdown/2024-10-27-70aeddb1fd9b.md.json
+++ b/tools/translators/cache/typo_check/zmediumtomarkdown/2024-10-27-70aeddb1fd9b.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "89e6e858e6116368396f38a5cf4503e01a071bda862e00b5e28383e2e8dc5998"
+}

--- a/tools/translators/cache/typo_check/zmediumtomarkdown/2024-12-02-aacd5f5cacd1.md.json
+++ b/tools/translators/cache/typo_check/zmediumtomarkdown/2024-12-02-aacd5f5cacd1.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "6af9bcfb1965c4b91169267a12fa84cf9e74aab510f95733c7aa2162ba6335d3"
+}

--- a/tools/translators/cache/typo_check/zmediumtomarkdown/2025-01-01-a8925ad9ed01.md.json
+++ b/tools/translators/cache/typo_check/zmediumtomarkdown/2025-01-01-a8925ad9ed01.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "931a6b613da4e4fb15625c8dc22be6041f65f667c0e3845762a674c1e308d102"
+}

--- a/tools/translators/cache/typo_check/zmediumtomarkdown/2025-01-11-4cb4437818f2.md.json
+++ b/tools/translators/cache/typo_check/zmediumtomarkdown/2025-01-11-4cb4437818f2.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "cffa7ebb90d7bd933fb154c077b11396732972e4901679a1a44ff2e222a90757"
+}

--- a/tools/translators/cache/typo_check/zmediumtomarkdown/2025-01-18-5bb7d3a4954f.md.json
+++ b/tools/translators/cache/typo_check/zmediumtomarkdown/2025-01-18-5bb7d3a4954f.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "fbdce3d8621a7bdabdf353fcd145e3110cad1b3a2138f109a1c6b934de35b3e4"
+}

--- a/tools/translators/cache/typo_check/zmediumtomarkdown/2025-03-02-fd719053b376.md.json
+++ b/tools/translators/cache/typo_check/zmediumtomarkdown/2025-03-02-fd719053b376.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "4cfb0f4f58cbd255a41ee23e878562b3fd7d228356797c57534f87ee66bbf048"
+}

--- a/tools/translators/cache/typo_check/zmediumtomarkdown/2025-03-20-71400d408dc8.md.json
+++ b/tools/translators/cache/typo_check/zmediumtomarkdown/2025-03-20-71400d408dc8.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "d71e34c46685f3cee7010b14fe040affd8444d13a5a0eec174f74ac7b752d725"
+}

--- a/tools/translators/cache/typo_check/zmediumtomarkdown/2025-04-03-6fd11e9704f2.md.json
+++ b/tools/translators/cache/typo_check/zmediumtomarkdown/2025-04-03-6fd11e9704f2.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "b52c4e8e0590570d34997023cf01a546fea1ca3b7a07ca113c593c7fc6c61daa"
+}

--- a/tools/translators/cache/typo_check/zmediumtomarkdown/2025-04-11-7508328d8b8d.md.json
+++ b/tools/translators/cache/typo_check/zmediumtomarkdown/2025-04-11-7508328d8b8d.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "39a5f1dcf43e0d55541c3227c177291b7e10e632aaa12991c8332a048bd3f79e"
+}

--- a/tools/translators/cache/typo_check/zmediumtomarkdown/2025-06-30-c008a9e8ceca.md.json
+++ b/tools/translators/cache/typo_check/zmediumtomarkdown/2025-06-30-c008a9e8ceca.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "84e670f3fbff4fcfffb8cb72701e8acec11290a91e1291c1f2fe52c150fce910"
+}

--- a/tools/translators/cache/typo_check/zmediumtomarkdown/2025-07-02-404bd5c70040.md.json
+++ b/tools/translators/cache/typo_check/zmediumtomarkdown/2025-07-02-404bd5c70040.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "44049384a6976ce753b003b3e79641ab2015faca0621fb6375fa0a0922e57378"
+}

--- a/tools/translators/cache/typo_check/zmediumtomarkdown/2025-07-07-4b001d2e8440.md.json
+++ b/tools/translators/cache/typo_check/zmediumtomarkdown/2025-07-07-4b001d2e8440.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "b4d46c77dcf4e42a39025f53eff3503c646aa47eb62bf5c9692bec4193270c87"
+}

--- a/tools/translators/cache/typo_check/zmediumtomarkdown/2025-07-10-4273e57e7148.md.json
+++ b/tools/translators/cache/typo_check/zmediumtomarkdown/2025-07-10-4273e57e7148.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "73fdf66ee5e752870be675b856d6b0943b14e5866eb696013218efd152a9e8e5"
+}

--- a/tools/translators/cache/typo_check/zmediumtomarkdown/2025-07-24-ba132457e6a5.md.json
+++ b/tools/translators/cache/typo_check/zmediumtomarkdown/2025-07-24-ba132457e6a5.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "7ebfdd3ae6aec81d0c556fc2d370c15c5bdfc1e17c3ee1056acf70686adc8c44"
+}

--- a/tools/translators/cache/typo_check/zmediumtomarkdown/2025-08-13-8ace34a1a3d8.md.json
+++ b/tools/translators/cache/typo_check/zmediumtomarkdown/2025-08-13-8ace34a1a3d8.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "80c3b2c65f833902acaece4c5c464c7069fb08b2551b64da6bd9b1a9963c4ab3"
+}

--- a/tools/translators/cache/typo_check/zmediumtomarkdown/2025-09-02-e4d139fe0685.md.json
+++ b/tools/translators/cache/typo_check/zmediumtomarkdown/2025-09-02-e4d139fe0685.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "149540dfb6a84b0711e6884dfcc821ac785881ba2c2356dbf18b3bb49a51d731"
+}

--- a/tools/translators/cache/typo_check/zmediumtomarkdown/2025-10-10-958599363857.md.json
+++ b/tools/translators/cache/typo_check/zmediumtomarkdown/2025-10-10-958599363857.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "b6060c4986d55b718e19ccd4647c62bb6c606f051eae72ce092fc50b821a72ec"
+}

--- a/tools/translators/cache/typo_check/zmediumtomarkdown/2025-10-26-bea62c251f1b.md.json
+++ b/tools/translators/cache/typo_check/zmediumtomarkdown/2025-10-26-bea62c251f1b.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "a63cc2e411a4573dcb34728b165a6eba99a1b96c155ee18db14f34b2c8f903f1"
+}

--- a/tools/translators/cache/typo_check/zmediumtomarkdown/2025-12-14-62f68ebeecd3.md.json
+++ b/tools/translators/cache/typo_check/zmediumtomarkdown/2025-12-14-62f68ebeecd3.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "d5167ef9195c3107aefdf43edaff66e77ac39439ffbb0392c9f26dabddd1225d"
+}

--- a/tools/translators/cache/typo_check/zmediumtomarkdown/2025-12-27-7c0974856393.md.json
+++ b/tools/translators/cache/typo_check/zmediumtomarkdown/2025-12-27-7c0974856393.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "0226db6dcf4586a897fc51ca377ee0278e45de49a2da165347addbf3116355dc"
+}

--- a/tools/translators/cache/typo_check/zmediumtomarkdown/2025-12-31-88f0fb935120.md.json
+++ b/tools/translators/cache/typo_check/zmediumtomarkdown/2025-12-31-88f0fb935120.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "d7fa1624184118b9b31ad8bb5ef8567101d58ee570281c936891c5ac9f89a4b4"
+}

--- a/tools/translators/cache/typo_check/zmediumtomarkdown/2026-01-03-823ac523ccc8.md.json
+++ b/tools/translators/cache/typo_check/zmediumtomarkdown/2026-01-03-823ac523ccc8.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "2ebce3ca91b1ca1530a3d70fd878869d47b96d201b616d4b24f295b9198cc19b"
+}

--- a/tools/translators/cache/typo_check/zmediumtomarkdown/2026-04-19-055527a739dd.md.json
+++ b/tools/translators/cache/typo_check/zmediumtomarkdown/2026-04-19-055527a739dd.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "e5407d99731b041cf8dffc184093f316764388966074f6c02de2612ee1bf8f80"
+}

--- a/tools/translators/cache/typo_check/zmediumtomarkdown/2026-04-27-6bf79c5b4dab.md.json
+++ b/tools/translators/cache/typo_check/zmediumtomarkdown/2026-04-27-6bf79c5b4dab.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "fe22072793a66c4fd6c28ae23de50df719136d0c1a2c0e93108444036f715617"
+}

--- a/tools/translators/cache/typo_check/zmediumtomarkdown/2026-05-03-35cc65327d28.md.json
+++ b/tools/translators/cache/typo_check/zmediumtomarkdown/2026-05-03-35cc65327d28.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "993f7fcc9c6eb3c26f56b4eedde0f9947f2b68628088e3096f1534e12f7492c9"
+}

--- a/tools/translators/cache/typo_check/zmediumtomarkdown/2026-05-08-0d4a5fd2929b.md.json
+++ b/tools/translators/cache/typo_check/zmediumtomarkdown/2026-05-08-0d4a5fd2929b.md.json
@@ -1,0 +1,5 @@
+{
+  "blocks": {},
+  "seeded": true,
+  "source_hash": "bed0b127a3a2f9cc43a9156c7bc22f0b915210f359f62cee50de48cc44bd0277"
+}

--- a/tools/translators/typo_checker.py
+++ b/tools/translators/typo_checker.py
@@ -221,11 +221,59 @@ def process_file(filename, src_dir, sub, api_key):
     save_cache(cache_p, {"source_hash": new_hash, "blocks": blocks_cache})
 
 
+def seed_file(filename, src_dir, sub):
+    """Pre-populate cache so old files are treated as already-checked.
+
+    Writes the current source_hash with an empty blocks map. Future runs will
+    short-circuit on the source_hash match (zero API). If the file is later
+    updated, source_hash mismatches and the normal check path runs.
+    """
+    src_path = os.path.join(src_dir, filename)
+    cache_p = cache_path(sub, filename)
+    if os.path.exists(cache_p):
+        return False  # don't overwrite existing cache
+    try:
+        with open(src_path, "r", encoding="utf-8") as f:
+            post = frontmatter.load(f)
+    except Exception as e:
+        print(f"✗ seed read failed: {filename} — {e}")
+        return False
+    save_cache(cache_p, {
+        "source_hash": compute_hash(post.content),
+        "blocks": {},
+        "seeded": True,
+    })
+    return True
+
+
 def main():
     parser = argparse.ArgumentParser(description="Check typos in zh-tw posts via OpenAI.")
     parser.add_argument("--api-key", help="OpenAI API key (or env OPENAI_API_KEY)")
     parser.add_argument("--max-workers", type=int, default=5)
+    parser.add_argument(
+        "--seed",
+        action="store_true",
+        help=(
+            "Seed cache for all current files without calling OpenAI. Use this "
+            "once when introducing the checker so existing articles are treated "
+            "as already-clean; only future fetches/updates trigger checks."
+        ),
+    )
     args = parser.parse_args()
+
+    if args.seed:
+        seeded = 0
+        for sub in SUBDIRS:
+            src_dir = os.path.join(ROOT, "L10n", "posts", SRC_LANG, sub)
+            if not os.path.isdir(src_dir):
+                continue
+            for f in sorted(os.listdir(src_dir)):
+                if not f.endswith((".md", ".markdown")):
+                    continue
+                if seed_file(f, src_dir, sub):
+                    seeded += 1
+        print(f"🌱 seeded {seeded} file(s) into typo_check cache (no API calls)")
+        return
 
     api_key = args.api_key or os.getenv("OPENAI_API_KEY")
     if not api_key:


### PR DESCRIPTION
## Summary

在 PR #211 之上補一個 **「舊文章不要跑 typo check」** 的調整：避免第一次跑 workflow 時 OpenAI 對所有 130+ 篇現有 zh-tw 文章全部重打一遍。

### 變更

- **`tools/translators/typo_checker.py`**：新增 `--seed` 旗標。對所有 zh-tw 檔案以當前 `source_hash` 寫入 cache（`blocks: {}`、`seeded: true`），完全不打 API。
- **`tools/translators/cache/typo_check/`**：執行 `python tools/translators/typo_checker.py --seed` 的產物，132 個 cache 檔（127 篇 `zmediumtomarkdown` + 5 篇 `ai`）一起 commit 進來。
- **`tools/translators/README.md`**：補充 seed 流程的說明。

### 實際行為

- 第一次跑 workflow → 所有舊文章 source_hash 全部命中 cache → 全部 skip → API 呼叫數 = 0。
- ZMediumToMarkdown 之後抓回**新文章**（沒有 cache 檔）→ 走檢查流程。
- ZMediumToMarkdown 抓回**內容更新的舊文章**（hash 變動）→ 走檢查流程（block 級 cache 還是空，所以該檔每個 block 會重檢一次；後續若再次更新就只重檢被改動的 block）。
- 想強制重檢某篇舊文：手動刪掉對應 cache JSON，下次跑就會走完整檢查。

成本：seed 是 0 美元；之後每月 cron 約只會打 0–幾百次 API（看當月新增/更新文章量）。

## Test plan

- [ ] 手動 trigger `ZMediumToMarkdown` workflow，確認 typo_checker step 跑完 log 顯示 0 個檔案被檢查（全部 cache hit）
- [ ] 故意改一個 zh-tw 檔的內容後再 trigger，確認該檔會被檢查
- [ ] 故意刪一個 cache 檔再 trigger，確認該檔會被重檢

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AU1nY8wsHJFxq5SHecLCM6)_