### PR TITLE
fix: dedupe BlogPosting JSON-LD (drop jekyll-seo-tag's stock block)

### DIFF
--- a/_plugins/strip_seo_tag_schema.rb
+++ b/_plugins/strip_seo_tag_schema.rb
@@ -1,0 +1,47 @@
+# Drop jekyll-seo-tag's stock BlogPosting / Article JSON-LD so the only
+# BlogPosting that ships is _includes/schema/article.html (which has
+# articleSection / keywords / inLanguage / publisher / full Person author —
+# the jekyll-seo-tag version is a strict subset).
+#
+# Two BlogPosting blocks per page is technically legal (Google merges) but
+# pollutes Rich Results Test, doubles the JSON-LD payload, and risks the
+# crawler picking the less-complete one. Cleaner to ship just our own.
+#
+# Identification: the jekyll-seo-tag block lacks `publisher` (our schema
+# always emits one). Belt + braces: also require lack of `articleSection`,
+# so we never strip a hand-rolled block that just happens to omit publisher.
+
+require 'json'
+
+module ZhgChgLi
+  module StripSeoTagSchema
+    SCRIPT_RE = /<script type="application\/ld\+json">(.*?)<\/script>/m
+
+    module_function
+
+    def rewrite(html)
+      return html unless html
+      html.gsub(SCRIPT_RE) do |match|
+        begin
+          parsed = JSON.parse($1)
+        rescue JSON::ParserError
+          next match
+        end
+        next match unless parsed.is_a?(Hash)
+        next match unless %w[BlogPosting Article].include?(parsed['@type'])
+        next match if parsed.key?('publisher') || parsed.key?('articleSection')
+        '' # drop
+      end
+    end
+  end
+
+  Jekyll::Hooks.register :posts, :post_render do |post|
+    next unless post.output
+    post.output = StripSeoTagSchema.rewrite(post.output)
+  end
+
+  Jekyll::Hooks.register :pages, :post_render do |page|
+    next unless page.output
+    page.output = StripSeoTagSchema.rewrite(page.output)
+  end
+end


### PR DESCRIPTION
## Summary

Follow-up to #220. After the SEO overhaul, every post had **two** `<script type="application/ld+json">` BlogPosting blocks:

- **Block 0** — emitted by `{% seo %}` (jekyll-seo-tag, stock): basic, author is name only, no `publisher` / `articleSection` / `keywords` / `inLanguage`
- **Block 1** — emitted by `_includes/schema/article.html` (added in #220): complete BlogPosting with everything above + full Person author with `sameAs` / `description` / `image`

Two BlogPosting is legal (Google merges) but pollutes Rich Results Test and risks the crawler picking the lite one. Cleaner to ship only the complete version.

## Fix

New `_plugins/strip_seo_tag_schema.rb` runs at `:post_render` and drops any `BlogPosting` / `Article` block that lacks **both** `publisher` and `articleSection` — a tight signature that only matches jekyll-seo-tag's stock output (our schema always includes both).

## Test plan

- [x] `bundle exec jekyll build` clean
- [x] Sample post `view-source`: 4 JSON-LD blocks (was 5) — BlogPosting (full) / BreadcrumbList / FAQPage / HowTo
- [x] Surviving BlogPosting has `publisher` + `articleSection` + `keywords` + `inLanguage` + full author Person
- [x] Homepage unaffected (still WebSite × 2 + Person — the WebSite ones don't match the strip signature)
- [ ] Rich Results Test: surviving BlogPosting passes (no duplicate warning)

🤖 Generated with [Claude Code](https://claude.com/claude-code)